### PR TITLE
bnb.js: pass copy of AUTO_TYPE to solve state leak

### DIFF
--- a/src/bnb.js
+++ b/src/bnb.js
@@ -34,7 +34,7 @@ module.exports = function(hex, type = 'AUTO') {
         return unMarshalBinaryLengthPrefixed(Buffer.from(hex,'hex'), TYPE[type]).val
     }
     else if (type === 'AUTO') {
-        return unMarshalBinaryLengthPrefixed(Buffer.from(hex,'hex'), AUTO_TYPE, typeFactory).val
+        return unMarshalBinaryLengthPrefixed(Buffer.from(hex,'hex'), Object.assign({}, AUTO_TYPE), typeFactory).val
     }
     else throw 'type should be one of the built-in types of passed in as object';
 }

--- a/src/utils/amino.js
+++ b/src/utils/amino.js
@@ -93,10 +93,8 @@ const decodeObjectBinary = (bytes, type, isLengthPrefixed, messageFactory) => {
   // If registered concrete, consume and verify prefix bytes.
   if(type.msgType) {
     const actualMsgType = bytes.slice(0, 4);
-    console.log('ACTUAL MSG TYPE', actualMsgType.toString('hex'));
     if (type.msgType === 'AUTO' && messageFactory) { // Automatically set the type of message
       const newType = messageFactory(actualMsgType.toString('hex'));
-      console.log('Replaceing type with ', type, newType)
       if (!newType) {
         console.warn('Unrecognized message type', actualMsgType);
       }


### PR DESCRIPTION
The encoded manipulates the state of the type that is passed into
the unmarshal function which causes a big state bug when the type is
passed in by reference.

The user facing problem is that if you unMarshal a batch of transactions, they will all return the same data.

The fix is to pass a copy of AUTO_TYPE.